### PR TITLE
Add audio resampling to `PunctuationRestorer`

### DIFF
--- a/src/speechbox/__init__.py
+++ b/src/speechbox/__init__.py
@@ -24,9 +24,9 @@
 
 __version__ = "0.1.2"
 
-from .utils import is_accelerate_available, is_transformers_available
+from .utils import is_accelerate_available, is_scipy_available, is_transformers_available
 
-if is_transformers_available() and is_accelerate_available():
+if is_transformers_available() and is_accelerate_available() and is_scipy_available():
     from .restore import PunctuationRestorer
 else:
     from .utils.dummy_transformers_and_accelerate_objects import *

--- a/src/speechbox/utils/__init__.py
+++ b/src/speechbox/utils/__init__.py
@@ -1,2 +1,7 @@
-from .import_utils import (DummyObject, is_accelerate_available,
-                           is_transformers_available, requires_backends)
+from .import_utils import (
+    DummyObject,
+    is_accelerate_available,
+    is_scipy_available,
+    is_transformers_available,
+    requires_backends,
+)

--- a/src/speechbox/utils/import_utils.py
+++ b/src/speechbox/utils/import_utils.py
@@ -42,12 +42,24 @@ except importlib_metadata.PackageNotFoundError:
     _accelerate_available = False
 
 
+_scipy_available = importlib.util.find_spec("scipy") is not None
+try:
+    _ = importlib_metadata.version("scipy")
+    _scipy_metadata = importlib_metadata.metadata("scipy")
+except importlib_metadata.PackageNotFoundError:
+    _scipy_available = False
+
+
 def is_transformers_available():
     return _transformers_available
 
 
 def is_accelerate_available():
     return _accelerate_available
+
+
+def is_scipy_available():
+    return _scipy_available
 
 
 TRANSFORMERS_IMPORT_ERROR = """
@@ -60,10 +72,16 @@ ACCELERATE_IMPORT_ERROR = """
 """
 
 
+SCIPY_IMPORT_ERROR = """
+{0} requires the scipy library but it was not found in your environment. You can install it with pip: `pip install scipy`. Please note that you may need to restart your runtime after installation.
+"""
+
+
 BACKENDS_MAPPING = OrderedDict(
     [
         ("transformers", (is_transformers_available, TRANSFORMERS_IMPORT_ERROR)),
         ("accelerate", (is_accelerate_available, ACCELERATE_IMPORT_ERROR)),
+        ("scipy", (is_scipy_available, SCIPY_IMPORT_ERROR)),
     ]
 )
 


### PR DESCRIPTION
Hi @patrickvonplaten 👋,

As discussed in https://github.com/huggingface/speechbox/issues/4, this PR

- [x] Adds resampling (scipy's version) into the `__call__` method of the `PunctuationRestorer`
- [x] Adds Scipy as a soft dependency for `PunctuationRestorer`

Below is a test snippet

```python
import string
import re
from datasets import load_dataset
from speechbox import PunctuationRestorer

streamed_dataset = load_dataset("mozilla-foundation/common_voice_11_0", "en", split="validation", streaming=True)

# get first sample
sample = next(iter(streamed_dataset))

# print out normalized transcript
print(sample["sentence"])
# => "It is from Westport, above the villages of Murrisk and Lecanvey."
sentence = re.sub(rf"[{re.escape(string.punctuation)}]", "", sample["sentence"]).lower()
print(sentence)
# => "it is from westport above the villages of murrisk and lecanvey"

# load the restoring class
restorer = PunctuationRestorer.from_pretrained("openai/whisper-tiny.en")
restorer.to("cuda")

restored_text, log_probs = restorer(sample["audio"]["array"], sentence, sampling_rate=sample["audio"]["sampling_rate"], num_beams=1)

print("Restored text:\n", restored_text)
# Restored text:
# It is from Westport above the villages of MURRISK and LECANVEY.
```