### PR TITLE
Fix for JSON serialization not available in pyannote.core 5.x #13

### DIFF
--- a/src/speechbox/diarize.py
+++ b/src/speechbox/diarize.py
@@ -88,7 +88,7 @@ class ASRDiarizationPipeline:
         )
 
         segments = []
-        for segment, track, label in annotation.itertracks(yield_label=True):
+        for segment, track, label in diarization.itertracks(yield_label=True):
             segments.append({'segment': {'start': segment.start, 'end': segment.end},
                              'track': track,
                              'label': label})

--- a/src/speechbox/diarize.py
+++ b/src/speechbox/diarize.py
@@ -87,7 +87,11 @@ class ASRDiarizationPipeline:
             **kwargs,
         )
 
-        segments = diarization.for_json()["content"]
+        segments = []
+        for segment, track, label in annotation.itertracks(yield_label=True):
+            segments.append({'segment': {'start': segment.start, 'end': segment.end},
+                             'track': track,
+                             'label': label})
 
         # diarizer output may contain consecutive segments from the same speaker (e.g. {(0 -> 1, speaker_1), (1 -> 1.5, speaker_1), ...})
         # we combine these segments to give overall timestamps for each speaker's turn (e.g. {(0 -> 1.5, speaker_1), ...})


### PR DESCRIPTION
Replaced deprecated for_json() with itertracks method