### PR TITLE
Default to 3.1 diarizer model

### DIFF
--- a/src/speechbox/diarize.py
+++ b/src/speechbox/diarize.py
@@ -25,7 +25,7 @@ class ASRDiarizationPipeline:
         cls,
         asr_model: Optional[str] = "openai/whisper-medium",
         *,
-        diarizer_model: Optional[str] = "pyannote/speaker-diarization",
+        diarizer_model: Optional[str] = "pyannote/speaker-diarization-3.1",
         chunk_length_s: Optional[int] = 30,
         use_auth_token: Optional[Union[str, bool]] = True,
         **kwargs,


### PR DESCRIPTION
Current implementation (following the readme example) gives error: ImportError: 'speechbrain' must be installed to use 'speechbrain/spkrec-ecapa-voxceleb' embeddings. Visit https://speechbrain.github.io for installation instructions.

Using 3.1 model fixes this. This fix should result in readme example code correctly executing. This also resolves some other warnings:
Model was trained with pyannote.audio 0.0.1, yours is 3.1.1. Bad things might happen unless you revert pyannote.audio to 0.x.
Model was trained with torch 1.10.0+cu102, yours is 2.4.0. Bad things might happen unless you revert torch to 1.x.